### PR TITLE
Hotfix: Add matplotlib to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit>=1.28.0
 pandas>=2.0.0
 numpy>=1.24.0
 plotly>=5.17.0
+matplotlib>=3.7.0


### PR DESCRIPTION
## Description
Hotfix to add missing matplotlib dependency to requirements.txt.

## Changes
- ✅ Added matplotlib>=3.7.0 to requirements.txt

## Related Issue
Part of #6 - Streamlit Cloud deployment

## Type
Hotfix - Critical dependency missing