### PR TITLE
feat: implement SQLite backend with user authentication (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ Thumbs.db
 
 # App-specific
 decisions.json
+decisions.db
+decisions.db-journal
 
 # Python
 *.pyc

--- a/decisions.json
+++ b/decisions.json
@@ -346,5 +346,143 @@
         "Total Score": 5.28
       }
     ]
+  },
+  {
+    "timestamp": "Nov 07, 2025",
+    "datetime": "2025-11-07T22:09:29.736939",
+    "decision": "dfsdf",
+    "options": [
+      "sdfas",
+      "sdfasdf"
+    ],
+    "criteria": [
+      "Cost",
+      "Comfortability",
+      "Time"
+    ],
+    "weights": [
+      0.32258064516129037,
+      0.4516129032258065,
+      0.22580645161290325
+    ],
+    "winner": "sdfasdf",
+    "winner_score": 8.0,
+    "full_results": [
+      {
+        "Option": "sdfasdf",
+        "Cost (1-10)": 8,
+        "Cost (Weighted)": 2.58,
+        "Comfortability (1-10)": 8,
+        "Comfortability (Weighted)": 3.61,
+        "Time (1-10)": 8,
+        "Time (Weighted)": 1.81,
+        "Total Score": 8.0
+      },
+      {
+        "Option": "sdfas",
+        "Cost (1-10)": 8,
+        "Cost (Weighted)": 2.58,
+        "Comfortability (1-10)": 7,
+        "Comfortability (Weighted)": 3.16,
+        "Time (1-10)": 5,
+        "Time (Weighted)": 1.13,
+        "Total Score": 6.87
+      }
+    ]
+  },
+  {
+    "timestamp": "Nov 07, 2025",
+    "datetime": "2025-11-07T22:24:17.793189",
+    "decision": "ok ",
+    "options": [
+      "1",
+      "2",
+      "3",
+      "4"
+    ],
+    "criteria": [
+      "Costsdfasdf",
+      "Comfortabilityadsfasdf",
+      "Time",
+      "adsfsdf",
+      "sdfasdf",
+      "dfasdf"
+    ],
+    "weights": [
+      0.04109589041095891,
+      0.136986301369863,
+      0.136986301369863,
+      0.3082191780821918,
+      0.3082191780821918,
+      0.0684931506849315
+    ],
+    "winner": "4",
+    "winner_score": 8.799999999999999,
+    "full_results": [
+      {
+        "Option": "4",
+        "Costsdfasdf (1-10)": 10,
+        "Costsdfasdf (Weighted)": 0.41,
+        "Comfortabilityadsfasdf (1-10)": 7,
+        "Comfortabilityadsfasdf (Weighted)": 0.96,
+        "Time (1-10)": 7,
+        "Time (Weighted)": 0.96,
+        "adsfsdf (1-10)": 9,
+        "adsfsdf (Weighted)": 2.77,
+        "sdfasdf (1-10)": 10,
+        "sdfasdf (Weighted)": 3.08,
+        "dfasdf (1-10)": 9,
+        "dfasdf (Weighted)": 0.62,
+        "Total Score": 8.799999999999999
+      },
+      {
+        "Option": "1",
+        "Costsdfasdf (1-10)": 5,
+        "Costsdfasdf (Weighted)": 0.21,
+        "Comfortabilityadsfasdf (1-10)": 5,
+        "Comfortabilityadsfasdf (Weighted)": 0.68,
+        "Time (1-10)": 7,
+        "Time (Weighted)": 0.96,
+        "adsfsdf (1-10)": 8,
+        "adsfsdf (Weighted)": 2.47,
+        "sdfasdf (1-10)": 9,
+        "sdfasdf (Weighted)": 2.77,
+        "dfasdf (1-10)": 9,
+        "dfasdf (Weighted)": 0.62,
+        "Total Score": 7.71
+      },
+      {
+        "Option": "3",
+        "Costsdfasdf (1-10)": 5,
+        "Costsdfasdf (Weighted)": 0.21,
+        "Comfortabilityadsfasdf (1-10)": 7,
+        "Comfortabilityadsfasdf (Weighted)": 0.96,
+        "Time (1-10)": 8,
+        "Time (Weighted)": 1.1,
+        "adsfsdf (1-10)": 5,
+        "adsfsdf (Weighted)": 1.54,
+        "sdfasdf (1-10)": 5,
+        "sdfasdf (Weighted)": 1.54,
+        "dfasdf (1-10)": 5,
+        "dfasdf (Weighted)": 0.34,
+        "Total Score": 5.6899999999999995
+      },
+      {
+        "Option": "2",
+        "Costsdfasdf (1-10)": 5,
+        "Costsdfasdf (Weighted)": 0.21,
+        "Comfortabilityadsfasdf (1-10)": 5,
+        "Comfortabilityadsfasdf (Weighted)": 0.68,
+        "Time (1-10)": 5,
+        "Time (Weighted)": 0.68,
+        "adsfsdf (1-10)": 5,
+        "adsfsdf (Weighted)": 1.54,
+        "sdfasdf (1-10)": 5,
+        "sdfasdf (Weighted)": 1.54,
+        "dfasdf (1-10)": 5,
+        "dfasdf (Weighted)": 0.34,
+        "Total Score": 4.99
+      }
+    ]
   }
 ]

--- a/src/app.py
+++ b/src/app.py
@@ -8,12 +8,20 @@ import pandas as pd
 import plotly.express as px
 import streamlit as st
 
+from database import authenticate_user, create_user
+from database import delete_decision as db_delete_decision
+from database import get_decision_by_id, get_user_decisions, init_database
+from database import save_decision as db_save_decision
+
 # === CONFIG ===
 st.set_page_config(
     page_title="Yes? AI Decision Guide", page_icon="✅", layout="centered"
 )
 
-# File path for decisions storage
+# Initialize database
+init_database()
+
+# File path for decisions storage (for migration)
 DECISIONS_FILE = "decisions.json"
 
 
@@ -65,40 +73,212 @@ with st.expander(
             st.session_state["has_seen_welcome"] = True
             st.rerun()
 
-# Sidebar: Mock Login + History
+# Sidebar: User Authentication + History
 with st.sidebar:
     st.header("👤 Account")
-    if st.checkbox("Enable Sync (Mock Login)", value=True):
-        st.success("Synced across devices")
+
+    # Initialize user session state
+    if "user_id" not in st.session_state:
+        st.session_state["user_id"] = None
+    if "username" not in st.session_state:
+        st.session_state["username"] = None
+    if "show_login" not in st.session_state:
+        st.session_state["show_login"] = True
+    if "show_signup" not in st.session_state:
+        st.session_state["show_signup"] = False
+    # Initialize temporary decisions storage
+    if "temp_decisions" not in st.session_state:
+        st.session_state["temp_decisions"] = []
+
+    # User authentication UI
+    if st.session_state["user_id"] is None:
+        # Not logged in - show login/signup
+        if st.session_state["show_signup"]:
+            st.subheader("📝 Sign Up")
+            new_username = st.text_input("Username", key="signup_username")
+            new_password = st.text_input(
+                "Password", type="password", key="signup_password"
+            )
+            confirm_password = st.text_input(
+                "Confirm Password", type="password", key="signup_confirm"
+            )
+
+            col1, col2 = st.columns(2)
+            with col1:
+                if st.button("Sign Up", type="primary", width="stretch"):
+                    if not new_username or not new_password:
+                        st.error("Please enter username and password")
+                    elif new_password != confirm_password:
+                        st.error("Passwords do not match")
+                    else:
+                        user_id = create_user(new_username, new_password)
+                        if user_id:
+                            st.session_state["user_id"] = user_id
+                            st.session_state["username"] = new_username
+                            st.session_state["show_signup"] = False
+                            # Migrate temporary decisions to database if any exist
+                            temp_decisions = st.session_state.get("temp_decisions", [])
+                            if temp_decisions:
+                                migrated_count = 0
+                                for temp_decision in temp_decisions:
+                                    try:
+                                        db_save_decision(
+                                            user_id=user_id,
+                                            decision=temp_decision["decision"],
+                                            options=temp_decision["options"],
+                                            criteria=temp_decision["criteria"],
+                                            weights=temp_decision["weights"],
+                                            scores=temp_decision["scores"],
+                                            winner=temp_decision["winner"],
+                                            winner_score=temp_decision["winner_score"],
+                                        )
+                                        migrated_count += 1
+                                    except Exception:
+                                        pass  # Skip failed migrations
+                                if migrated_count > 0:
+                                    st.session_state["temp_decisions"] = []
+                                    st.success(
+                                        f"Welcome, {new_username}! Migrated {migrated_count} temporary decision(s)."
+                                    )
+                                else:
+                                    st.success(f"Welcome, {new_username}!")
+                            else:
+                                st.success(f"Welcome, {new_username}!")
+                            st.rerun()
+                        else:
+                            st.error("Username already exists")
+            with col2:
+                if st.button("Back to Login", width="stretch"):
+                    st.session_state["show_signup"] = False
+                    st.rerun()
+        else:
+            st.subheader("🔐 Login")
+            username = st.text_input("Username", key="login_username")
+            password = st.text_input("Password", type="password", key="login_password")
+
+            col1, col2 = st.columns(2)
+            with col1:
+                if st.button("Login", type="primary", width="stretch"):
+                    if not username or not password:
+                        st.error("Please enter username and password")
+                    else:
+                        user_id = authenticate_user(username, password)
+                        if user_id:
+                            st.session_state["user_id"] = user_id
+                            st.session_state["username"] = username
+                            # Migrate temporary decisions to database if any exist
+                            temp_decisions = st.session_state.get("temp_decisions", [])
+                            if temp_decisions:
+                                migrated_count = 0
+                                for temp_decision in temp_decisions:
+                                    try:
+                                        db_save_decision(
+                                            user_id=user_id,
+                                            decision=temp_decision["decision"],
+                                            options=temp_decision["options"],
+                                            criteria=temp_decision["criteria"],
+                                            weights=temp_decision["weights"],
+                                            scores=temp_decision["scores"],
+                                            winner=temp_decision["winner"],
+                                            winner_score=temp_decision["winner_score"],
+                                        )
+                                        migrated_count += 1
+                                    except Exception:
+                                        pass  # Skip failed migrations
+                                if migrated_count > 0:
+                                    st.session_state["temp_decisions"] = []
+                                    st.success(
+                                        f"Welcome back, {username}! Migrated {migrated_count} temporary decision(s)."
+                                    )
+                                else:
+                                    st.success(f"Welcome back, {username}!")
+                            else:
+                                st.success(f"Welcome back, {username}!")
+                            st.rerun()
+                        else:
+                            st.error("Invalid username or password")
+            with col2:
+                if st.button("Sign Up", width="stretch"):
+                    st.session_state["show_signup"] = True
+                    st.rerun()
     else:
-        st.warning("Offline mode")
+        # Logged in - show user info and logout
+        st.success(f"✅ Logged in as **{st.session_state['username']}**")
+        if st.button("🚪 Logout", width="stretch"):
+            st.session_state["user_id"] = None
+            st.session_state["username"] = None
+            # Clear any loaded decision data
+            for key in ["load_decision", "decision_to_load", "show_load_confirm"]:
+                if key in st.session_state:
+                    del st.session_state[key]
+            st.rerun()
 
     st.header("📜 Past Decisions")
-    # Load decisions from local JSON file
-    if os.path.exists(DECISIONS_FILE):
-        try:
-            with open(DECISIONS_FILE, "r") as f:
-                all_decisions = json.load(f)
-            # Display most recent 5 decisions
-            if all_decisions:
-                for idx, decision_data in enumerate(all_decisions[-5:]):
-                    entry = f"{decision_data['decision']} → **{decision_data['winner']}** ({decision_data['winner_score']:.1f})"
-                    # Create a button that covers both emoji and text
+
+    # Load decisions from database for logged-in user
+    if st.session_state["user_id"] is not None:
+        user_decisions = get_user_decisions(st.session_state["user_id"], limit=10)
+        if user_decisions:
+            for idx, decision_data in enumerate(user_decisions):
+                entry = f"{decision_data['decision']} → **{decision_data['winner']}** ({decision_data['winner_score']:.1f})"
+                # Create a button that covers both emoji and text
+                col1, col2 = st.columns([4, 1])
+                with col1:
                     if st.button(
                         f"📋 {entry}",
-                        key=f"load_{idx}_{len(all_decisions)}",
+                        key=f"load_{decision_data['id']}",
                         help=f"Load this decision",
                         width="stretch",
                     ):
                         # Store the decision to load in session state
                         st.session_state["decision_to_load"] = decision_data
                         st.session_state["show_load_confirm"] = True
-            else:
-                st.write("• No decisions saved yet")
-        except (json.JSONDecodeError, KeyError) as e:
-            st.write("• No valid decisions found")
+                with col2:
+                    if st.button(
+                        "🗑️",
+                        key=f"delete_{decision_data['id']}",
+                        help="Delete this decision",
+                    ):
+                        if db_delete_decision(
+                            decision_data["id"], st.session_state["user_id"]
+                        ):
+                            st.success("Decision deleted")
+                            st.rerun()
+                        else:
+                            st.error("Failed to delete decision")
+        else:
+            st.write("• No decisions saved yet")
     else:
-        st.write("• No decisions saved yet")
+        # Show temporary decisions for non-logged-in users
+        temp_decisions = st.session_state.get("temp_decisions", [])
+        if temp_decisions:
+            st.caption(
+                "💡 *Temporary decisions (lost on refresh). Log in to save permanently.*"
+            )
+            for idx, decision_data in enumerate(temp_decisions):
+                entry = f"{decision_data['decision']} → **{decision_data['winner']}** ({decision_data['winner_score']:.1f})"
+                col1, col2 = st.columns([4, 1])
+                with col1:
+                    if st.button(
+                        f"📋 {entry}",
+                        key=f"load_temp_{idx}",
+                        help=f"Load this temporary decision",
+                        width="stretch",
+                    ):
+                        # Store the decision to load in session state
+                        st.session_state["decision_to_load"] = decision_data
+                        st.session_state["show_load_confirm"] = True
+                with col2:
+                    if st.button(
+                        "🗑️",
+                        key=f"delete_temp_{idx}",
+                        help="Delete this temporary decision",
+                    ):
+                        st.session_state["temp_decisions"].pop(idx)
+                        st.success("Decision deleted")
+                        st.rerun()
+        else:
+            st.info("👆 Log in to save permanently, or save temporarily below")
 
 # === CONFIRMATION DIALOG ===
 # Confirmation dialog for loading a decision (in main area)
@@ -428,9 +608,14 @@ with st.container(border=True):
 # === SAVE DECISION ===
 with st.container(border=True):
     st.markdown("### 💾 Save Your Decision")
-    st.caption(
-        "💡 Save this decision to review later. You can load it from the sidebar anytime."
-    )
+    if st.session_state["user_id"] is None:
+        st.caption(
+            "💡 Save temporarily (lost on refresh) or log in to save permanently. You can load it from the sidebar anytime."
+        )
+    else:
+        st.caption(
+            "💡 Save this decision to review later. You can load it from the sidebar anytime."
+        )
 
     if st.button("💾 Save This Decision", width="stretch"):
         timestamp = datetime.now().strftime("%b %d, %Y")
@@ -438,7 +623,18 @@ with st.container(border=True):
             f"{decision} → **{df.iloc[0]['Option']}** ({df.iloc[0]['Total Score']:.1f})"
         )
 
-        # Save to local file
+        # Prepare scores dictionary for database from DataFrame
+        # The DataFrame already has all the scores we need
+        scores_dict = {}
+        for opt_idx, opt in enumerate(options):
+            scores_dict[opt] = {}
+            for param_idx, param in enumerate(params):
+                # Get score from DataFrame
+                score_col = f"{param} (1-10)"
+                score = float(df[df["Option"] == opt][score_col].iloc[0])
+                scores_dict[opt][param] = score
+
+        # Prepare decision data
         decision_data = {
             "timestamp": timestamp,
             "datetime": datetime.now().isoformat(),
@@ -449,23 +645,33 @@ with st.container(border=True):
             "winner": df.iloc[0]["Option"],
             "winner_score": float(df.iloc[0]["Total Score"]),
             "full_results": df.to_dict("records"),
+            "scores": scores_dict,
         }
 
-        # Load existing decisions or create new list
-        if os.path.exists(DECISIONS_FILE):
-            with open(DECISIONS_FILE, "r") as f:
-                all_decisions = json.load(f)
+        if st.session_state["user_id"] is None:
+            # Save temporarily to session state
+            if "temp_decisions" not in st.session_state:
+                st.session_state["temp_decisions"] = []
+            st.session_state["temp_decisions"].append(decision_data)
+            st.success(f"💾 Saved temporarily: {entry}")
+            st.info(
+                "💡 *This decision will be lost on refresh. Log in to save permanently.*"
+            )
         else:
-            all_decisions = []
+            # Save to database
+            decision_id = db_save_decision(
+                user_id=st.session_state["user_id"],
+                decision=decision,
+                options=options,
+                criteria=params,
+                weights=weights,
+                scores=scores_dict,
+                winner=df.iloc[0]["Option"],
+                winner_score=float(df.iloc[0]["Total Score"]),
+            )
+            decision_data["id"] = decision_id
+            st.success(f"✅ Saved permanently: {entry}")
 
-        # Append new decision
-        all_decisions.append(decision_data)
-
-        # Save back to file
-        with open(DECISIONS_FILE, "w") as f:
-            json.dump(all_decisions, f, indent=2)
-
-        st.success(f"Saved: {entry}")
         st.rerun()  # Refresh the app to update Past Decisions
 
 # === FULL TABLE ===

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,394 @@
+"""
+Database module for SQLite backend with user authentication and decision storage.
+"""
+
+import hashlib
+import os
+import sqlite3
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+# Database file path
+DB_FILE = "decisions.db"
+
+
+def get_db_connection():
+    """Get database connection."""
+    conn = sqlite3.connect(DB_FILE)
+    conn.row_factory = sqlite3.Row  # Return rows as dictionaries
+    return conn
+
+
+def init_database():
+    """Initialize database with tables."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    # Users table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """
+    )
+
+    # Decisions table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS decisions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            decision TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            datetime TEXT NOT NULL,
+            winner TEXT NOT NULL,
+            winner_score REAL NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    """
+    )
+
+    # Options table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS options (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            decision_id INTEGER NOT NULL,
+            option_name TEXT NOT NULL,
+            FOREIGN KEY (decision_id) REFERENCES decisions(id)
+        )
+    """
+    )
+
+    # Criteria table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS criteria (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            decision_id INTEGER NOT NULL,
+            criterion TEXT NOT NULL,
+            weight REAL NOT NULL,
+            FOREIGN KEY (decision_id) REFERENCES decisions(id)
+        )
+    """
+    )
+
+    # Scores table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            option_id INTEGER NOT NULL,
+            criterion_id INTEGER NOT NULL,
+            score REAL NOT NULL,
+            FOREIGN KEY (option_id) REFERENCES options(id),
+            FOREIGN KEY (criterion_id) REFERENCES criteria(id)
+        )
+    """
+    )
+
+    conn.commit()
+    conn.close()
+
+
+def hash_password(password: str) -> str:
+    """Hash password using SHA256."""
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def create_user(username: str, password: str) -> Optional[int]:
+    """Create a new user. Returns user_id if successful, None otherwise."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    try:
+        password_hash = hash_password(password)
+        cursor.execute(
+            "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+            (username, password_hash),
+        )
+        user_id = cursor.lastrowid
+        conn.commit()
+        return user_id
+    except sqlite3.IntegrityError:
+        # Username already exists
+        return None
+    finally:
+        conn.close()
+
+
+def authenticate_user(username: str, password: str) -> Optional[int]:
+    """Authenticate user. Returns user_id if successful, None otherwise."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    password_hash = hash_password(password)
+    cursor.execute(
+        "SELECT id FROM users WHERE username = ? AND password_hash = ?",
+        (username, password_hash),
+    )
+    result = cursor.fetchone()
+    user_id = result["id"] if result else None
+    conn.close()
+
+    return user_id
+
+
+def save_decision(
+    user_id: int,
+    decision: str,
+    options: List[str],
+    criteria: List[str],
+    weights: List[float],
+    scores: Dict[str, Dict[str, float]],
+    winner: str,
+    winner_score: float,
+) -> int:
+    """Save a decision to the database. Returns decision_id."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    timestamp = datetime.now().strftime("%b %d, %Y")
+    datetime_str = datetime.now().isoformat()
+
+    # Insert decision
+    cursor.execute(
+        """
+        INSERT INTO decisions (user_id, decision, timestamp, datetime, winner, winner_score)
+        VALUES (?, ?, ?, ?, ?, ?)
+    """,
+        (user_id, decision, timestamp, datetime_str, winner, winner_score),
+    )
+    decision_id = cursor.lastrowid
+
+    # Insert options
+    option_ids = {}
+    for option in options:
+        cursor.execute(
+            "INSERT INTO options (decision_id, option_name) VALUES (?, ?)",
+            (decision_id, option),
+        )
+        option_ids[option] = cursor.lastrowid
+
+    # Insert criteria
+    criterion_ids = {}
+    for criterion, weight in zip(criteria, weights):
+        cursor.execute(
+            "INSERT INTO criteria (decision_id, criterion, weight) VALUES (?, ?, ?)",
+            (decision_id, criterion, weight),
+        )
+        criterion_ids[criterion] = cursor.lastrowid
+
+    # Insert scores
+    for option, criterion_scores in scores.items():
+        option_id = option_ids[option]
+        for criterion, score in criterion_scores.items():
+            criterion_id = criterion_ids[criterion]
+            cursor.execute(
+                "INSERT INTO scores (option_id, criterion_id, score) VALUES (?, ?, ?)",
+                (option_id, criterion_id, score),
+            )
+
+    conn.commit()
+    conn.close()
+    return decision_id
+
+
+def get_user_decisions(user_id: int, limit: int = 5) -> List[Dict[str, Any]]:
+    """Get user's decisions. Returns list of decision dictionaries."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        SELECT id, decision, timestamp, datetime, winner, winner_score
+        FROM decisions
+        WHERE user_id = ?
+        ORDER BY created_at DESC
+        LIMIT ?
+    """,
+        (user_id, limit),
+    )
+
+    decisions = []
+    for row in cursor.fetchall():
+        decision_id = row["id"]
+        decision_data = {
+            "id": decision_id,
+            "decision": row["decision"],
+            "timestamp": row["timestamp"],
+            "datetime": row["datetime"],
+            "winner": row["winner"],
+            "winner_score": row["winner_score"],
+        }
+
+        # Get options
+        cursor.execute(
+            "SELECT option_name FROM options WHERE decision_id = ?", (decision_id,)
+        )
+        decision_data["options"] = [
+            opt_row["option_name"] for opt_row in cursor.fetchall()
+        ]
+
+        # Get criteria and weights
+        cursor.execute(
+            "SELECT criterion, weight FROM criteria WHERE decision_id = ?",
+            (decision_id,),
+        )
+        criteria_data = cursor.fetchall()
+        decision_data["criteria"] = [
+            crit_row["criterion"] for crit_row in criteria_data
+        ]
+        decision_data["weights"] = [crit_row["weight"] for crit_row in criteria_data]
+
+        # Get scores
+        cursor.execute(
+            """
+            SELECT o.option_name, c.criterion, s.score
+            FROM scores s
+            JOIN options o ON s.option_id = o.id
+            JOIN criteria c ON s.criterion_id = c.id
+            WHERE o.decision_id = ?
+        """,
+            (decision_id,),
+        )
+        scores = {}
+        for score_row in cursor.fetchall():
+            option = score_row["option_name"]
+            criterion = score_row["criterion"]
+            score = score_row["score"]
+            if option not in scores:
+                scores[option] = {}
+            scores[option][criterion] = score
+        decision_data["scores"] = scores
+
+        # Reconstruct full_results for compatibility
+        decision_data["full_results"] = _reconstruct_full_results(decision_data)
+
+        decisions.append(decision_data)
+
+    conn.close()
+    return decisions
+
+
+def _reconstruct_full_results(decision_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Reconstruct full_results DataFrame-like structure from database data."""
+    results = []
+    for option in decision_data["options"]:
+        result = {"Option": option}
+        for criterion in decision_data["criteria"]:
+            score = decision_data["scores"].get(option, {}).get(criterion, 5.0)
+            result[f"{criterion} (1-10)"] = score
+        results.append(result)
+    return results
+
+
+def get_decision_by_id(decision_id: int, user_id: int) -> Optional[Dict[str, Any]]:
+    """Get a specific decision by ID. Returns None if not found or not owned by user."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        SELECT id, decision, timestamp, datetime, winner, winner_score
+        FROM decisions
+        WHERE id = ? AND user_id = ?
+    """,
+        (decision_id, user_id),
+    )
+
+    row = cursor.fetchone()
+    if not row:
+        conn.close()
+        return None
+
+    decision_data = {
+        "id": row["id"],
+        "decision": row["decision"],
+        "timestamp": row["timestamp"],
+        "datetime": row["datetime"],
+        "winner": row["winner"],
+        "winner_score": row["winner_score"],
+    }
+
+    # Get options
+    cursor.execute(
+        "SELECT option_name FROM options WHERE decision_id = ?", (decision_id,)
+    )
+    decision_data["options"] = [opt_row["option_name"] for opt_row in cursor.fetchall()]
+
+    # Get criteria and weights
+    cursor.execute(
+        "SELECT criterion, weight FROM criteria WHERE decision_id = ?", (decision_id,)
+    )
+    criteria_data = cursor.fetchall()
+    decision_data["criteria"] = [crit_row["criterion"] for crit_row in criteria_data]
+    decision_data["weights"] = [crit_row["weight"] for crit_row in criteria_data]
+
+    # Get scores
+    cursor.execute(
+        """
+        SELECT o.option_name, c.criterion, s.score
+        FROM scores s
+        JOIN options o ON s.option_id = o.id
+        JOIN criteria c ON s.criterion_id = c.id
+        WHERE o.decision_id = ?
+    """,
+        (decision_id,),
+    )
+    scores = {}
+    for score_row in cursor.fetchall():
+        option = score_row["option_name"]
+        criterion = score_row["criterion"]
+        score = score_row["score"]
+        if option not in scores:
+            scores[option] = {}
+        scores[option][criterion] = score
+    decision_data["scores"] = scores
+
+    # Reconstruct full_results
+    decision_data["full_results"] = _reconstruct_full_results(decision_data)
+
+    conn.close()
+    return decision_data
+
+
+def delete_decision(decision_id: int, user_id: int) -> bool:
+    """Delete a decision. Returns True if successful, False otherwise."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    # Check if decision exists and belongs to user
+    cursor.execute(
+        "SELECT id FROM decisions WHERE id = ? AND user_id = ?", (decision_id, user_id)
+    )
+    if not cursor.fetchone():
+        conn.close()
+        return False
+
+    # Delete scores (cascade)
+    cursor.execute(
+        """
+        DELETE FROM scores
+        WHERE option_id IN (SELECT id FROM options WHERE decision_id = ?)
+    """,
+        (decision_id,),
+    )
+
+    # Delete options
+    cursor.execute("DELETE FROM options WHERE decision_id = ?", (decision_id,))
+
+    # Delete criteria
+    cursor.execute("DELETE FROM criteria WHERE decision_id = ?", (decision_id,))
+
+    # Delete decision
+    cursor.execute("DELETE FROM decisions WHERE id = ?", (decision_id,))
+
+    conn.commit()
+    conn.close()
+    return True

--- a/src/migrate_json_to_db.py
+++ b/src/migrate_json_to_db.py
@@ -1,0 +1,121 @@
+"""
+Migration script to migrate decisions from JSON file to SQLite database.
+This script creates a default user and migrates all decisions to that user.
+"""
+
+import json
+import os
+
+from database import (create_user, get_db_connection, init_database,
+                      save_decision)
+
+# Database and JSON file paths
+DB_FILE = "decisions.db"
+JSON_FILE = "decisions.json"
+
+
+def migrate_json_to_db():
+    """Migrate decisions from JSON file to SQLite database."""
+    # Initialize database
+    init_database()
+
+    # Check if JSON file exists
+    if not os.path.exists(JSON_FILE):
+        print(f"❌ {JSON_FILE} not found. Nothing to migrate.")
+        return
+
+    # Load JSON data
+    try:
+        with open(JSON_FILE, "r") as f:
+            decisions_data = json.load(f)
+    except (json.JSONDecodeError, FileNotFoundError) as e:
+        print(f"❌ Error reading {JSON_FILE}: {e}")
+        return
+
+    if not decisions_data:
+        print(f"ℹ️  {JSON_FILE} is empty. Nothing to migrate.")
+        return
+
+    # Create default user for migration
+    default_username = "migrated_user"
+    default_password = "migrated_password_change_me"
+
+    # Check if user already exists
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM users WHERE username = ?", (default_username,))
+    existing_user = cursor.fetchone()
+    conn.close()
+
+    if existing_user:
+        user_id = existing_user["id"]
+        print(f"ℹ️  Using existing user: {default_username} (ID: {user_id})")
+    else:
+        user_id = create_user(default_username, default_password)
+        if user_id:
+            print(f"✅ Created default user: {default_username} (ID: {user_id})")
+            print(f"⚠️  Default password: {default_password}")
+            print(f"⚠️  Please change the password after migration!")
+        else:
+            print(f"❌ Failed to create default user")
+            return
+
+    # Migrate each decision
+    migrated_count = 0
+    skipped_count = 0
+
+    for decision_data in decisions_data:
+        try:
+            # Extract data from JSON format
+            decision = decision_data.get("decision", "")
+            options = decision_data.get("options", [])
+            criteria = decision_data.get("criteria", [])
+            weights = decision_data.get("weights", [])
+            winner = decision_data.get("winner", "")
+            winner_score = decision_data.get("winner_score", 0.0)
+
+            # Reconstruct scores from full_results
+            full_results = decision_data.get("full_results", [])
+            scores_dict = {}
+            for result in full_results:
+                option = result.get("Option", "")
+                if not option:
+                    continue
+                scores_dict[option] = {}
+                for criterion in criteria:
+                    score_key = f"{criterion} (1-10)"
+                    score = result.get(score_key, 5.0)
+                    scores_dict[option][criterion] = float(score)
+
+            # Save to database
+            decision_id = save_decision(
+                user_id=user_id,
+                decision=decision,
+                options=options,
+                criteria=criteria,
+                weights=weights,
+                scores=scores_dict,
+                winner=winner,
+                winner_score=winner_score,
+            )
+
+            migrated_count += 1
+            print(f"✅ Migrated: {decision} (ID: {decision_id})")
+
+        except Exception as e:
+            skipped_count += 1
+            print(f"⚠️  Skipped decision: {e}")
+
+    print(f"\n📊 Migration Summary:")
+    print(f"   ✅ Migrated: {migrated_count} decisions")
+    print(f"   ⚠️  Skipped: {skipped_count} decisions")
+    print(f"   👤 User: {default_username} (ID: {user_id})")
+    print(f"\n💡 Next steps:")
+    print(f"   1. Log in with username: {default_username}")
+    print(f"   2. Password: {default_password}")
+    print(f"   3. Change your password after logging in")
+    print(f"   4. Consider backing up {JSON_FILE} before deleting it")
+
+
+if __name__ == "__main__":
+    migrate_json_to_db()


### PR DESCRIPTION
## Description

Implements SQLite backend with user authentication and CRUD operations for decisions.

## Changes

- ✅ Add SQLite database with schema for users, decisions, options, criteria, scores
- ✅ Implement user authentication (login/signup) in Streamlit
- ✅ Replace JSON file operations with SQLite CRUD operations
- ✅ Add temporary decision storage for non-logged-in users
- ✅ Auto-migrate temporary decisions when user logs in/signs up
- ✅ Add delete functionality for decisions
- ✅ Create migration script from JSON to SQLite
- ✅ Update .gitignore to exclude database files

## Database Schema

- **users**: id, username, password_hash, created_at
- **decisions**: id, user_id, decision, timestamp, datetime, winner, winner_score, created_at
- **options**: id, decision_id, option_name
- **criteria**: id, decision_id, criterion, weight
- **scores**: id, option_id, criterion_id, score

## Features

- User accounts with login/signup
- User-specific decision history
- Temporary decision storage for non-logged-in users
- Auto-migration of temporary decisions when user logs in
- Delete functionality for decisions
- Migration script from JSON to SQLite

## Testing

- [x] User authentication works
- [x] Decisions save to database
- [x] Temporary decisions work for non-logged-in users
- [x] Auto-migration works when user logs in
- [x] Delete functionality works

## Related

Closes #4